### PR TITLE
integration test and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 language: go
-sudo: false
+
 go:
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - master
+  - 1.9
+
+go_import_path: gopkg.in/bblfsh/client-go.v0
+
+sudo: required
+
+services:
+  - docker
 
 before_install:
-  - make deps
-
-install:
-  - make build
+  - docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/server
+  - make dependencies
 
 script:
-  - make test
+  - make test-coverage
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ if err != nil {
 
 python := "import foo"
 
-res, err := client.NewParseRequest().Content(python).Do()
+res, err := client.NewParseRequest().Language("python").Content(python).Do()
 if err != nil {
     panic(err)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,29 @@
+package bblfsh
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	cli, err := NewBblfshClient("localhost:9432")
+	require.Nil(t, err)
+
+	python := "import foo"
+
+	res, err := cli.NewParseRequest().Language("python").Content(python).Do()
+	require.Nil(t, err)
+
+	fmt.Println(res.Errors)
+	fmt.Println(res.UAST)
+
+	require.Equal(t, len(res.Errors), 0)
+	require.NotNil(t, res.UAST)
+
+}

--- a/parse_request_test.go
+++ b/parse_request_test.go
@@ -1,8 +1,11 @@
 package bblfsh
 
-import "testing"
-import "gopkg.in/bblfsh/sdk.v0/protocol"
-import "github.com/stretchr/testify/require"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/bblfsh/sdk.v0/protocol"
+)
 
 func TestParseRequestConfiguration(t *testing.T) {
 	req := ParseRequest{}


### PR DESCRIPTION
It add a new integration test, the default `go test -v .` execute all the test, in order to skip this tests you should use the standard git flag `short`: `go test -v -short .`.

Also a server is executed in travis to be able to do a proper integration test. 