### PR TITLE
Update README to follow documentation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,9 @@ It is also possible to link against custom `libuast` on Windows, read [WINDOWS.m
 
 This small example illustrates how to retrieve the [UAST](https://doc.bblf.sh/uast/specification.html) from a small Python script.
 
-If you don't have a bblfsh server running you can execute it using the following command:
+If you don't have a bblfsh server installed, please read the [getting started](https://doc.bblf.sh/user/getting-started.html) guide, to learn more about how to use and deploy a bblfsh server. 
 
-```sh
-docker run --privileged --rm -d -p 9432:9432 --name bblfsh bblfsh/bblfshd
-```
-
-Please read the [getting started](https://doc.bblf.sh/user/getting-started.html) guide, to learn more about how to use and deploy a bblfsh server.
+Go to the[quick start](https://github.com/bblfsh/bblfshd#quick-start) to discover how to run Babelfish with Docker.
 
 ```go
 client, err := bblfsh.NewClient("0.0.0.0:9432")


### PR DESCRIPTION
This is so we don't keep outdated commands in the documentation, and follow our documentation guide. I noticed this when running babelfish from this README, and seeing that we have inconsistent naming of the container across our project (bblfsh vs bblfshd).