### PR TITLE
Typed filter functions for queries with boolean/number/string results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # libuast source code
 *.c
+*.cc
 *.h
 !bindings.h
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Package configuration
 PROJECT = client-go
-LIBUAST_VERSION=.1.8.1
+LIBUAST_VERSION=.1.8.2
 GOPATH ?= $(shell go env GOPATH)
 
 ifneq ($(OS),Windows_NT)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ defer iter.Dispose()
 for node := range iter.Iterate() {
     fmt.Println(node)
 }
+
+// For XPath expressions returning a boolean/numeric/string value, you must
+// use the right typed Filter function:
+
+boolres, err := FilterBool(res.UAST, "boolean(//*[@strtOffset or @endOffset])")
+strres, err := FilterString(res.UAST, "name(//*[1])")
+numres, err := FilterNumber(res.UAST, "count(//*)")
 ```
 
 Please read the [Babelfish clients](https://doc.bblf.sh/user/language-clients.html) guide section to learn more about babelfish clients and their query language.

--- a/tools/bindings.h
+++ b/tools/bindings.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h> // XXX
 
 #if __has_include("uast.h") // std C++17, GCC 5.x || Clang || VSC++ 2015u2+
 // Embedded mode on UNIX, MSVC build on Windows.

--- a/tools/bindings.h
+++ b/tools/bindings.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h> // XXX
 
 #if __has_include("uast.h") // std C++17, GCC 5.x || Clang || VSC++ 2015u2+
 // Embedded mode on UNIX, MSVC build on Windows.
@@ -161,6 +160,20 @@ static int FilterBool(uintptr_t node_ptr, const char *query) {
     return -1;
   }
   return (int)res;
+}
+
+static double FilterNumber(uintptr_t node_ptr, const char *query, int *ok) {
+  bool c_ok;
+  double res = UastFilterNumber(ctx, (void*)node_ptr, query, &c_ok);
+  if (!c_ok) {
+    *ok = 0;
+  }
+  *ok = 1;
+  return res;
+}
+
+static const char *FilterString(uintptr_t node_ptr, const char *query) {
+  return UastFilterString(ctx, (void*)node_ptr, query);
 }
 
 static uintptr_t IteratorNew(uintptr_t node_ptr, int order) {

--- a/tools/bindings.h
+++ b/tools/bindings.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h> // XXX
 
 #if __has_include("uast.h") // std C++17, GCC 5.x || Clang || VSC++ 2015u2+
 // Embedded mode on UNIX, MSVC build on Windows.
@@ -167,8 +168,9 @@ static double FilterNumber(uintptr_t node_ptr, const char *query, int *ok) {
   double res = UastFilterNumber(ctx, (void*)node_ptr, query, &c_ok);
   if (!c_ok) {
     *ok = 0;
+  } else {
+    *ok = 1;
   }
-  *ok = 1;
   return res;
 }
 

--- a/tools/bindings.h
+++ b/tools/bindings.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h> // XXX
 
 #if __has_include("uast.h") // std C++17, GCC 5.x || Clang || VSC++ 2015u2+
 // Embedded mode on UNIX, MSVC build on Windows.
@@ -153,6 +154,15 @@ static bool Filter(uintptr_t node_ptr, const char *query) {
   return nodes != NULL;
 }
 
+static int FilterBool(uintptr_t node_ptr, const char *query) {
+  bool ok;
+  bool res = UastFilterBool(ctx, (void*)node_ptr, query, &ok);
+  if (!ok) {
+    return -1;
+  }
+  return (int)res;
+}
+
 static uintptr_t IteratorNew(uintptr_t node_ptr, int order) {
   return (uintptr_t)UastIteratorNew(ctx, (void *)node_ptr, order);
 }
@@ -161,7 +171,7 @@ static uintptr_t IteratorNext(uintptr_t iter) {
   return (uintptr_t)UastIteratorNext((void*)iter);
 }
 
-static uintptr_t IteratorFree(uintptr_t iter) {
+static void IteratorFree(uintptr_t iter) {
   UastIteratorFree((void*)iter);
 }
 

--- a/tools/filter_test.go
+++ b/tools/filter_test.go
@@ -15,14 +15,14 @@ func TestFilter(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestFilterWrongType(t * testing.T) {
+func TestFilterWrongType(t *testing.T) {
 	n := &uast.Node{}
 
 	_, err := Filter(n, "boolean(//*[@startPosition or @endPosition])")
 	assert.NotNil(t, err)
 }
 
-func TestFilterBool(t * testing.T) {
+func TestFilterBool(t *testing.T) {
 	n := &uast.Node{}
 
 	r, err := FilterBool(n, "boolean(0)")
@@ -32,6 +32,28 @@ func TestFilterBool(t * testing.T) {
 	r, err = FilterBool(n, "boolean(1)")
 	assert.Nil(t, err)
 	assert.True(t, r)
+}
+
+func TestFilterNumber(t *testing.T) {
+	n := &uast.Node{}
+
+	r, err := FilterNumber(n, "count(//*)")
+	assert.Nil(t, err)
+	assert.Equal(t, int(r), 1)
+
+	n.Children = []*uast.Node{&uast.Node{}, &uast.Node{}}
+	r, err = FilterNumber(n, "count(//*)")
+	assert.Nil(t, err)
+	assert.Equal(t, int(r), 3)
+}
+
+func TestFilterString(t *testing.T) {
+	n := &uast.Node{}
+	n.InternalType = "TestType"
+
+	r, err := FilterString(n, "name(//*[1])")
+    assert.Nil(t, err)
+    assert.Equal(t, r, "TestType")
 }
 
 func TestFilter_All(t *testing.T) {

--- a/tools/filter_test.go
+++ b/tools/filter_test.go
@@ -15,6 +15,25 @@ func TestFilter(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestFilterWrongType(t * testing.T) {
+	n := &uast.Node{}
+
+	_, err := Filter(n, "boolean(//*[@startPosition or @endPosition])")
+	assert.NotNil(t, err)
+}
+
+func TestFilterBool(t * testing.T) {
+	n := &uast.Node{}
+
+	r, err := FilterBool(n, "boolean(0)")
+	assert.Nil(t, err)
+	assert.False(t, r)
+
+	r, err = FilterBool(n, "boolean(1)")
+	assert.Nil(t, err)
+	assert.True(t, r)
+}
+
 func TestFilter_All(t *testing.T) {
 	n := &uast.Node{}
 


### PR DESCRIPTION
- Adds bindings for libuast's `FilterBool`, `FilterNumber`, `FilterString`.
- Updates README.
- Fixes some `C.free()`s after returns **o_O** and thus memory leaks.
- Fixes #42.