### PR TITLE
Fix the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Package configuration
 PROJECT = client-go
-LIBUAST_VERSION=.1.8.2
+LIBUAST_VERSION ?= 1.8.2
 GOPATH ?= $(shell go env GOPATH)
 
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
The dot in the beginning of the version is a misprint, it breaks all the dependent projects because they fail to download the libuast tarball.

E.g. https://travis-ci.org/src-d/hercules/jobs/345297562#L1000

Signed-off-by: Vadim Markovtsev <vadim@sourced.tech>