### PR TITLE
Update libuast dependency. Small travis and Makefile fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90
   - docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/bblfshd
-  - docker exec -it bblfsh bblfshctl driver install --recommended
+  - docker exec -it bblfsh bblfshctl driver install python bblfsh/python-driver
   - make dependencies
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90
   - docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/bblfshd
+  - docker exec -it bblfsh bblfshctl driver install --recommended
   - make dependencies
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: go
 
 go:
+  - 1.8
   - 1.9
+  - "1.10"
+  - tip
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
 
 go_import_path: gopkg.in/bblfsh/client-go.v2
 
@@ -26,6 +34,8 @@ before_install:
   - make dependencies
 
 script:
+  - go test
+  - go test ./tools
   - make test-coverage
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 
 go:
-  - 1.8
   - 1.9
-  - "1.10"
   - tip
 
 matrix:

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,1 @@
-Alfredo Beaumont <alfredo@sourced.tech> (@abeaumont)
+Denys Smirnov <denys@sourced.tech> (@dennwc)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Package configuration
 PROJECT = client-go
-LIBUAST_VERSION ?= 1.9.0
+LIBUAST_VERSION ?= 1.9.1
 GOPATH ?= $(shell go env GOPATH)
 
 ifneq ($(OS),Windows_NT)
@@ -25,7 +25,7 @@ GOGET ?= go get
 
 clean: clean-libuast
 clean-libuast:
-	find ./ -name '*.[h,c]' ! -name 'bindings.h' -exec rm -f {} +
+	find ./  -regex '.*\.[h,c]c?' ! -name 'bindings.h' -exec rm -f {} +
 
 dependencies: cgo-dependencies
 ifneq ($(OS),Windows_NT)

--- a/tools/iterator_test.go
+++ b/tools/iterator_test.go
@@ -177,8 +177,8 @@ func TestIter_PositionOrder(t *testing.T) {
 
 	testIterNode(t, iter, "parent")
 	testIterNode(t, iter, "subchild22")
-	testIterNode(t, iter, "subchild21")
 	testIterNode(t, iter, "child1")
+	testIterNode(t, iter, "subchild21")
 	testIterNode(t, iter, "child2")
 
 	node, err := iter.Next()

--- a/tools/iterator_test.go
+++ b/tools/iterator_test.go
@@ -8,25 +8,25 @@ import (
 )
 
 func nodeTree() *uast.Node {
-	child1 := &uast.Node {
+	child1 := &uast.Node{
 		InternalType: "child1",
 	}
 
-	subchild21 := &uast.Node {
+	subchild21 := &uast.Node{
 		InternalType: "subchild21",
 	}
 
-	subchild22 := &uast.Node {
+	subchild22 := &uast.Node{
 		InternalType: "subchild22",
 	}
 
-	child2 := &uast.Node {
+	child2 := &uast.Node{
 		InternalType: "child2",
-		Children: []*uast.Node{subchild21, subchild22},
+		Children:     []*uast.Node{subchild21, subchild22},
 	}
 	parent := &uast.Node{
 		InternalType: "parent",
-		Children: []*uast.Node{child1, child2},
+		Children:     []*uast.Node{child1, child2},
 	}
 	return parent
 }
@@ -62,7 +62,8 @@ func TestIter_Finished(t *testing.T) {
 
 	iter, err := NewIterator(parent, PreOrder)
 	defer iter.Dispose()
-	for _ = range iter.Iterate() {}
+	for _ = range iter.Iterate() {
+	}
 
 	_, err = iter.Next()
 	assert.NotNil(t, err)
@@ -144,30 +145,30 @@ func TestIter_LevelOrder(t *testing.T) {
 }
 
 func TestIter_PositionOrder(t *testing.T) {
-	child1 := &uast.Node {
-		InternalType: "child1",
-		StartPosition: &uast.Position{Offset:10, Line:0, Col:0},
+	child1 := &uast.Node{
+		InternalType:  "child1",
+		StartPosition: &uast.Position{Offset: 10, Line: 0, Col: 0},
 	}
 
-	subchild21 := &uast.Node {
-		InternalType: "subchild21",
-		StartPosition: &uast.Position{Offset:10, Line:0, Col:0},
+	subchild21 := &uast.Node{
+		InternalType:  "subchild21",
+		StartPosition: &uast.Position{Offset: 10, Line: 0, Col: 0},
 	}
 
-	subchild22 := &uast.Node {
-		InternalType: "subchild22",
-		StartPosition: &uast.Position{Offset:5, Line:0, Col:0},
+	subchild22 := &uast.Node{
+		InternalType:  "subchild22",
+		StartPosition: &uast.Position{Offset: 5, Line: 0, Col: 0},
 	}
 
-	child2 := &uast.Node {
-		InternalType: "child2",
-		Children: []*uast.Node{subchild21, subchild22},
-		StartPosition: &uast.Position{Offset:15, Line:0, Col:0},
+	child2 := &uast.Node{
+		InternalType:  "child2",
+		Children:      []*uast.Node{subchild21, subchild22},
+		StartPosition: &uast.Position{Offset: 15, Line: 0, Col: 0},
 	}
 	parent := &uast.Node{
-		InternalType: "parent",
-		Children: []*uast.Node{child1, child2},
-		StartPosition: &uast.Position{Offset:0, Line:0, Col:0},
+		InternalType:  "parent",
+		Children:      []*uast.Node{child1, child2},
+		StartPosition: &uast.Position{Offset: 0, Line: 0, Col: 0},
 	}
 
 	iter, err := NewIterator(parent, PositionOrder)


### PR DESCRIPTION
- Added a reference to the root `uast.Node` (Go) pointer in the (Go) `Iterator` struct so it's not gc'ed after `NewIterator()`. Unset it on `it.Dispose()`. Fixes crashes with Go 1.9+.

- Update libuast dependency to 1.9.1 (fixes a potencial crash with position iterators).

- Change the order in the position iterator unittest for the one expected with the fixed libuast for nodes with the same position.

- Make travis fails if some test fails (wasn't doing it before).

- Install the Python driver for Travis (without it the request's tests were failing).

- Some other travis and Makefile fixes.

- GoFmt (sorry for the noise in the diff).

- Update maintainers file.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>