### PR TITLE
Test make dependencies on Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ PROJECT = client-go
 LIBUAST_VERSION ?= 1.9.1
 GOPATH ?= $(shell go env GOPATH)
 
+TOOLS_FOLDER = tools
+
 ifneq ($(OS),Windows_NT)
 COPY = cp
 else
@@ -10,17 +12,13 @@ COPY = copy
 endif
 
 # Including ci Makefile
-MAKEFILE = Makefile.main
-CI_REPOSITORY = https://github.com/src-d/ci.git
-CI_FOLDER = .ci
-
-TOOLS_FOLDER = tools
-
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_PATH ?= $(shell pwd)/.ci
+MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):
-	@(git clone --quiet $(CI_REPOSITORY) $(CI_FOLDER) && \
-	$(COPY) $(CI_FOLDER)/$(MAKEFILE) .);
-
+	git clone --quiet --depth 1 $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
+
 GOGET ?= go get
 
 clean: clean-libuast

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ else
 COPY = copy
 endif
 
+# 'Makefile::cgo-dependencies' target must be run before 'Makefile.main::dependencies' or 'go-get' will fail
+dependencies: cgo-dependencies
+
 # Including ci Makefile
 CI_REPOSITORY ?= https://github.com/src-d/ci.git
 CI_PATH ?= $(shell pwd)/.ci
@@ -19,31 +22,21 @@ $(MAKEFILE):
 	git clone --quiet --depth 1 $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
 
-GOGET ?= go get
-
 clean: clean-libuast
 clean-libuast:
 	find ./  -regex '.*\.[h,c]c?' ! -name 'bindings.h' -exec rm -f {} +
 
-dependencies: cgo-dependencies
 ifneq ($(OS),Windows_NT)
 cgo-dependencies:
 	curl -SL https://github.com/bblfsh/libuast/releases/download/v$(LIBUAST_VERSION)/libuast-v$(LIBUAST_VERSION).tar.gz | tar xz
 	mv libuast-v$(LIBUAST_VERSION)/src/* $(TOOLS_FOLDER)/.
 	rm -rf libuast-v$(LIBUAST_VERSION)
-	$(GOGET) ./...
 else
-binaries.win64.mingw\lib:
+cgo-dependencies:
 	go get -v github.com/mholt/archiver/cmd/archiver
 	cd $(TOOLS_FOLDER) && \
 	curl -SLko binaries.win64.mingw.zip https://github.com/bblfsh/libuast/releases/download/v$(LIBUAST_VERSION)/binaries.win64.mingw.zip && \
 	$(GOPATH)\bin\archiver open binaries.win64.mingw.zip && \
 	del /q binaries.win64.mingw.zip && echo done
-
-cgo-dependencies: binaries.win64.mingw\lib
-	$(GOGET) ./...
 endif  # !Windows_NT
 
-# $(DEPENDENCIES) it's allowed to file since the code is not compilable
-# without libuast.
-.IGNORE: $(DEPENDENCIES)


### PR DESCRIPTION
Trying to debug a related problem in `bblfsh/dashboard`, blocking https://github.com/bblfsh/dashboard/pull/105
https://travis-ci.org/bblfsh/dashboard/builds/361636871

reproduced here in `bblfsh/client-go` too at:
https://travis-ci.org/bblfsh/client-go/jobs/365140987

The problem in behinf is that running `make dependencies` causes an error because it executes `go get` that fails because there is missing stuff.

If it is run the `cgo-dependencies` before the `go get`, everything goes well.