### PR TITLE
[RFC] Throw error if no G++ or GCC are not available with a proper version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,22 @@ clean-libuast:
 	find ./  -regex '.*\.[h,c]c?' ! -name 'bindings.h' -exec rm -f {} +
 
 ifneq ($(OS),Windows_NT)
-cgo-dependencies:
+cgo-dependencies: check-gcc
 	curl -SL https://github.com/bblfsh/libuast/releases/download/v$(LIBUAST_VERSION)/libuast-v$(LIBUAST_VERSION).tar.gz | tar xz
 	mv libuast-v$(LIBUAST_VERSION)/src/* $(TOOLS_FOLDER)/.
 	rm -rf libuast-v$(LIBUAST_VERSION)
+check-gcc:
+	@if \
+		[[ -z `which gcc` ]] || \
+		[[ -z `which g++` ]] || \
+		[[ 5 -gt `gcc -dumpversion | sed -r 's/^[^0-9]*([0-9]+).*/\1/g'` ]] || \
+		[[ 5 -gt `g++ -dumpversion | sed -r 's/^[^0-9]*([0-9]+).*/\1/g'` ]]; \
+	then \
+		echo -e "error; GCC and G++ v5 or greater are required \n"; \
+		echo -e "- GCC: `gcc --version` \n"; \
+		echo -e "- G++: `g++ --version` \n"; \
+		exit 1; \
+	fi;
 else
 cgo-dependencies:
 	go get -v github.com/mholt/archiver/cmd/archiver


### PR DESCRIPTION
Throw an error if `GCC` and `G++` are not available with the required version; otherwise, `libuast` wouldn't compile.

If the check is not done, and the dependencies are not met, the error thrown is too cryptic and it can cause misunderstandings in the people as described by the issue https://github.com/bblfsh/client-go/issues/50

**Disclaimer:**
1. I'm not sure if the check for Unix could be wider considering `C++17, GCC 5.x || Clang || VSC++ 2015u2+` (by https://github.com/bblfsh/client-go/blob/master/tools/bindings.h#L8)
1. It would be needed to ckeck the same for Windows (I wonder if @vmarkovtsev could help as he did at https://github.com/bblfsh/client-go/commit/312df13cf2a6d450cf67ef76ab84e949d10abcd1#diff-113eb303bcf433a2bec7f3238b6240d3R8)