### PR TITLE
Make the client more safe

### DIFF
--- a/request.go
+++ b/request.go
@@ -1,12 +1,30 @@
 package bblfsh
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"path/filepath"
 
 	"gopkg.in/bblfsh/sdk.v1/protocol"
 )
+
+// FatalError is returned when response is returned with Fatal status code.
+type FatalError []string
+
+func (e FatalError) Error() string {
+	if n := len(e); n == 0 {
+		return "fatal error"
+	} else if n == 1 {
+		return e[0]
+	}
+	buf := bytes.NewBuffer(nil)
+	for _, s := range e {
+		buf.WriteString(s)
+		buf.WriteRune('\n')
+	}
+	return buf.String()
+}
 
 // ParseRequest is a parsing request to get the UAST.
 type ParseRequest struct {
@@ -68,7 +86,13 @@ func (r *ParseRequest) DoWithContext(ctx context.Context) (*protocol.ParseRespon
 		return nil, r.err
 	}
 
-	return r.client.service.Parse(ctx, &r.internal)
+	resp, err := r.client.service.Parse(ctx, &r.internal)
+	if err != nil {
+		return nil, err
+	} else if resp.Status == protocol.Fatal {
+		return nil, FatalError(resp.Errors)
+	}
+	return resp, nil
 }
 
 // NativeParseRequest is a parsing request to get the AST.
@@ -131,7 +155,13 @@ func (r *NativeParseRequest) DoWithContext(ctx context.Context) (*protocol.Nativ
 		return nil, r.err
 	}
 
-	return r.client.service.NativeParse(ctx, &r.internal)
+	resp, err := r.client.service.NativeParse(ctx, &r.internal)
+	if err != nil {
+		return nil, err
+	} else if resp.Status == protocol.Fatal {
+		return nil, FatalError(resp.Errors)
+	}
+	return resp, nil
 }
 
 // VersionRequest is a request to retrieve the version of the server.
@@ -153,7 +183,13 @@ func (r *VersionRequest) DoWithContext(ctx context.Context) (*protocol.VersionRe
 		return nil, r.err
 	}
 
-	return r.client.service.Version(ctx, &protocol.VersionRequest{})
+	resp, err := r.client.service.Version(ctx, &protocol.VersionRequest{})
+	if err != nil {
+		return nil, err
+	} else if resp.Status == protocol.Fatal {
+		return nil, FatalError(resp.Errors)
+	}
+	return resp, nil
 }
 
 // SupportedLanguagesRequest is a request to retrieve the supported languages.
@@ -175,5 +211,11 @@ func (r *SupportedLanguagesRequest) DoWithContext(ctx context.Context) (*protoco
 		return nil, r.err
 	}
 
-	return r.client.service.SupportedLanguages(ctx, &protocol.SupportedLanguagesRequest{})
+	resp, err := r.client.service.SupportedLanguages(ctx, &protocol.SupportedLanguagesRequest{})
+	if err != nil {
+		return nil, err
+	} else if resp.Status == protocol.Fatal {
+		return nil, FatalError(resp.Errors)
+	}
+	return resp, nil
 }

--- a/request.go
+++ b/request.go
@@ -90,7 +90,7 @@ func (r *ParseRequest) DoWithContext(ctx context.Context) (*protocol.ParseRespon
 	if err != nil {
 		return nil, err
 	} else if resp.Status == protocol.Fatal {
-		return nil, FatalError(resp.Errors)
+		return resp, FatalError(resp.Errors)
 	}
 	return resp, nil
 }
@@ -159,7 +159,7 @@ func (r *NativeParseRequest) DoWithContext(ctx context.Context) (*protocol.Nativ
 	if err != nil {
 		return nil, err
 	} else if resp.Status == protocol.Fatal {
-		return nil, FatalError(resp.Errors)
+		return resp, FatalError(resp.Errors)
 	}
 	return resp, nil
 }
@@ -187,7 +187,7 @@ func (r *VersionRequest) DoWithContext(ctx context.Context) (*protocol.VersionRe
 	if err != nil {
 		return nil, err
 	} else if resp.Status == protocol.Fatal {
-		return nil, FatalError(resp.Errors)
+		return resp, FatalError(resp.Errors)
 	}
 	return resp, nil
 }
@@ -215,7 +215,7 @@ func (r *SupportedLanguagesRequest) DoWithContext(ctx context.Context) (*protoco
 	if err != nil {
 		return nil, err
 	} else if resp.Status == protocol.Fatal {
-		return nil, FatalError(resp.Errors)
+		return resp, FatalError(resp.Errors)
 	}
 	return resp, nil
 }

--- a/request.go
+++ b/request.go
@@ -1,10 +1,10 @@
 package bblfsh
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/bblfsh/sdk.v1/protocol"
 )
@@ -15,15 +15,8 @@ type FatalError []string
 func (e FatalError) Error() string {
 	if n := len(e); n == 0 {
 		return "fatal error"
-	} else if n == 1 {
-		return e[0]
 	}
-	buf := bytes.NewBuffer(nil)
-	for _, s := range e {
-		buf.WriteString(s)
-		buf.WriteRune('\n')
-	}
-	return buf.String()
+	return strings.Join([]string(e), "\n")
 }
 
 // ParseRequest is a parsing request to get the UAST.

--- a/tools/bindings.go
+++ b/tools/bindings.go
@@ -109,7 +109,7 @@ func errorFilter(name string) error {
 // returning the list of nodes that satisfy the given query.
 // Filter is thread-safe but not concurrent by an internal global lock.
 func Filter(node *uast.Node, xpath string) ([]*uast.Node, error) {
-	if len(xpath) == 0 {
+	if len(xpath) == 0 || node == nil {
 		return nil, nil
 	}
 
@@ -132,7 +132,7 @@ func Filter(node *uast.Node, xpath string) ([]*uast.Node, error) {
 // return type (e.g. when using XPath functions returning a boolean type).
 // FilterBool is thread-safe but not concurrent by an internal global lock.
 func FilterBool(node *uast.Node, xpath string) (bool, error) {
-	if len(xpath) == 0 {
+	if len(xpath) == 0 || node == nil {
 		return false, nil
 	}
 
@@ -160,8 +160,8 @@ func FilterBool(node *uast.Node, xpath string) (bool, error) {
 // return type (e.g. when using XPath functions returning a float type).
 // FilterNumber is thread-safe but not concurrent by an internal global lock.
 func FilterNumber(node *uast.Node, xpath string) (float64, error) {
-	if len(xpath) == 0 {
-		return 0.0, nil
+	if len(xpath) == 0 || node == nil {
+		return 0, nil
 	}
 
 	cquery, ptr := initFilter(node, xpath)
@@ -180,7 +180,7 @@ func FilterNumber(node *uast.Node, xpath string) (float64, error) {
 // return type (e.g. when using XPath functions returning a string type).
 // FilterString is thread-safe but not concurrent by an internal global lock.
 func FilterString(node *uast.Node, xpath string) (string, error) {
-	if len(xpath) == 0 {
+	if len(xpath) == 0 || node == nil {
 		return "", nil
 	}
 

--- a/tools/cstring_pool.go
+++ b/tools/cstring_pool.go
@@ -14,7 +14,7 @@ func (pool *cstringPool) getCstring(str string) *C.char {
 	return ptr
 }
 
-func (*cstringPool) release() {
+func (pool *cstringPool) release() {
 	for _, ptr := range pool.pointers {
 		C.free(ptr)
 	}

--- a/tools/cstring_pool.go
+++ b/tools/cstring_pool.go
@@ -18,5 +18,5 @@ func (*cstringPool) release() {
 	for _, ptr := range pool.pointers {
 		C.free(ptr)
 	}
-	pool.pointers = pool.pointers[0:0]
+	pool.pointers = pool.pointers[:0]
 }


### PR DESCRIPTION
* Return a Go error when a response has a Fatal status. Fixes #60.

* Check the passed node pointer in filters. Fixes #60.

* Return a closer function from filter init - fewer chances to forget to call it.

* Fix C string pool that was releasing pointers from a global instance only.

* Cache property keys instead of collecting sorting them each time.