### PR TITLE
Bump libuast version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Package configuration
 PROJECT = client-go
-LIBUAST_VERSION ?= 2.0.0
+LIBUAST_VERSION ?= 2.0.1
 
 TOOLS_FOLDER = tools
 

--- a/tools/uast.cc
+++ b/tools/uast.cc
@@ -281,8 +281,11 @@ Nodes *UastFilter(const Uast *ctx, NodeHandle node, const char *query) {
 
     auto nodeset = queryResult.xpathObj->nodesetval;
     if (!nodeset) {
-        Error(nullptr, "Unable to get array of result nodes\n");
+      if (NodesSetSize(nodes, 0) != 0) {
+        Error(nullptr, "Unable to set nodes size\n");
         throw std::runtime_error("");
+      }
+      return nodes;
     }
 
     auto results = nodeset->nodeTab;


### PR DESCRIPTION
Bump libuast dependency version to v2.0.1 (edit: and ran `make dependencies`) to get the fix for the empty queries over properties returning an error (see bblfsh/libuast/pull/86).

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>