### PR TITLE
cli: support UAST mode parameter

### DIFF
--- a/request.go
+++ b/request.go
@@ -78,6 +78,20 @@ const (
 	Semantic  = protocol2.Mode_Semantic
 )
 
+// Parse mode parses a UAST mode string to an enum value.
+func ParseMode(mode string) (Mode, error) {
+	// TODO: define this function in SDK
+	switch mode {
+	case "native":
+		return Native, nil
+	case "annotated":
+		return Annotated, nil
+	case "semantic":
+		return Semantic, nil
+	}
+	return 0, fmt.Errorf("unsupported mode: %q", mode)
+}
+
 // Mode controls the level of transformation applied to UAST.
 func (r *ParseRequestV2) Mode(mode Mode) *ParseRequestV2 {
 	r.internal.Mode = mode


### PR DESCRIPTION
Add support for `--mode` parameter for both v1 and v2 mode.

This allows running XPath from the CLI for Semantic UAST (in v1 mode).

Signed-off-by: Denys Smirnov <denys@sourced.tech>