### PR TITLE
Preview of v2 XPath support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/antchfx/xpath"
+  packages = ["."]
+  revision = "c2547b7f965a33cc46f0883f6d8bccda62ecb2c0"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -166,15 +172,19 @@
     "driver",
     "driver/manifest",
     "protocol",
+    "protocol/v1",
     "uast",
     "uast/nodes",
     "uast/nodes/nodesproto",
     "uast/nodes/nodesproto/pio",
+    "uast/query",
+    "uast/query/xpath",
     "uast/role",
-    "uast/transformer"
+    "uast/transformer",
+    "uast/yaml"
   ]
-  revision = "7afaacbde549f1711442ee62a7a646a799653833"
-  version = "v2.0.1"
+  revision = "87d72062a52cbfe5b52a606f98ec53a29ac94e28"
+  version = "v2.2.0"
 
 [[projects]]
   name = "gopkg.in/src-d/go-errors.v1"
@@ -182,9 +192,15 @@
   revision = "8bbbeeb767dfdd053b9b45d5a16a4f4ce2c6f694"
   version = "v1.0.0"
 
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "29f27f33cbaccf6fd14ced092a26593aa3b09fc9bc646ffcd475f7fb72760606"
+  inputs-digest = "403f83976885d8f2dd873c1db6df963e4a5685e217103ac49dca60d0fbd9d472"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,7 +19,7 @@
 
 [[constraint]]
   name = "gopkg.in/bblfsh/sdk.v2"
-  version = "2.0.x"
+  version = "2.2.x"
 
 [prune]
   go-tests = true

--- a/tools/uast_v2.go
+++ b/tools/uast_v2.go
@@ -1,0 +1,18 @@
+package tools
+
+import (
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+	"gopkg.in/bblfsh/sdk.v2/uast/query"
+	"gopkg.in/bblfsh/sdk.v2/uast/query/xpath"
+)
+
+// FilterXPath takes a `Node` as returned by UAST() call and an xpath query and filters the tree,
+// returning the iterator of nodes that satisfy the given query.
+func (c *Context) FilterXPath(node nodes.External, query string) (query.Iterator, error) {
+	return FilterXPath(node, query)
+}
+
+// FilterXPath is a shorthand for Context.FilterXPath.
+func FilterXPath(node nodes.External, query string) (query.Iterator, error) {
+	return xpath.New().Execute(node, query)
+}

--- a/tools/uast_v2_test.go
+++ b/tools/uast_v2_test.go
@@ -1,0 +1,60 @@
+package tools
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/bblfsh/sdk.v2/protocol/v1"
+	"gopkg.in/bblfsh/sdk.v2/uast/yaml"
+)
+
+const fixture = `./testdata/json.go.sem.uast`
+
+func BenchmarkXPathV1(b *testing.B) {
+	data, err := ioutil.ReadFile(fixture)
+	require.NoError(b, err)
+	node, err := uastyml.Unmarshal(data)
+	require.NoError(b, err)
+
+	node1, err := uast1.ToNode(node)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		arr, err := Filter(node1, `//Identifier`)
+		if err != nil {
+			b.Fatal(err)
+		} else if len(arr) != 2292 {
+			b.Fatal("wrong result:", len(arr))
+		}
+	}
+}
+
+func BenchmarkXPathV2(b *testing.B) {
+	data, err := ioutil.ReadFile(fixture)
+	require.NoError(b, err)
+	node, err := uastyml.Unmarshal(data)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		it, err := FilterXPath(node, `//uast:Identifier`)
+		if err != nil {
+			b.Fatal(err)
+		}
+		cnt := 0
+		for it.Next() {
+			cnt++
+			_ = it.Node()
+		}
+		if cnt != 2292 {
+			b.Fatal("wrong result:", cnt)
+		}
+	}
+}


### PR DESCRIPTION
This PR exposes an XPath query support for UAST v2. It's intended to serve as a preview for the new major version of Go client.

It also contains a benchmark that compares XPath based on libuast (in C) vs XPath implemented in Babelfish SDK (in Go).

Results:
```
BenchmarkXPathV1-4       10      166194261 ns/op       2610198 B/op      18037 allocs/op
BenchmarkXPathV2-4       30       53743641 ns/op      35384852 B/op     394715 allocs/op
```

Signed-off-by: Denys Smirnov <denys@sourced.tech>