### PR TITLE
Add .proto output support for V1 requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
 
 jobs:
   include:
-    - {go: 1.9.x,  os: linux, sudo: required, dist: trusty, services: [docker]}
-    - {go: 1.10.x, os: linux, sudo: required, dist: trusty, services: [docker]}
-    - {go: 1.9.x,  os: osx, osx_image: xcode9.3}
-    - {go: 1.10.x, os: osx, osx_image: xcode9.3}
+    - {go: '1.10.x',  os: linux, sudo: required, dist: trusty, services: [docker]}
+    - {go: '1.11.x', os: linux, sudo: required, dist: trusty, services: [docker]}
+    - {go: '1.10.x',  os: osx, osx_image: xcode9.3}
+    - {go: '1.11.x', os: osx, osx_image: xcode9.3}

--- a/cmd/bblfsh-cli/main.go
+++ b/cmd/bblfsh-cli/main.go
@@ -130,7 +130,7 @@ func main() {
 			fatalf("failed to encode UAST to Protobuf: %v", err)
 		}
 
-		ioutil.WriteFile(outFileName, []byte(protoUast), 0644)
+		err = ioutil.WriteFile(outFileName, []byte(protoUast), 0644)
 		if err != nil {
 			fatalf("failed to write Protobuf to %s, %v", outFileName, err)
 		}

--- a/cmd/bblfsh-cli/main.go
+++ b/cmd/bblfsh-cli/main.go
@@ -119,10 +119,10 @@ func main() {
 		fmt.Printf("%s\n", b)
 	case "proto":
 		if opts.V2 || opts.Query != "" {
-			fatalf(".proto output format is only supported for V1 requests without any queries")
+			fatalf(".pb output format is only supported for V1 requests without any queries")
 		}
 
-		outFileName := fmt.Sprintf("./%s.proto", filepath.Base(filename))
+		outFileName := fmt.Sprintf("./%s.pb", filepath.Base(filename))
 		fmt.Fprintf(os.Stderr, "Saving result to %s\n", outFileName)
 
 		protoUast, err := res.UAST.Marshal()
@@ -134,6 +134,8 @@ func main() {
 		if err != nil {
 			fatalf("failed to write Protobuf to %s, %v", outFileName, err)
 		}
+	default:
+		fatalf("unsupported output format: %q", opts.Out)
 	}
 }
 


### PR DESCRIPTION
Legacy code, moved out of `bblfsh-sdk` binary, shall not to be supported in future.

Part of the https://github.com/bblfsh/sdk/pull/314

Now there is `--out json|proto` options, where `proto` only works for V1 and is going to write output to `./file.pb`.

